### PR TITLE
Fix QA history handling bugs

### DIFF
--- a/src/main/java/coen6761/project/RobotMotion.java
+++ b/src/main/java/coen6761/project/RobotMotion.java
@@ -161,14 +161,17 @@ public class RobotMotion {
                         processCommand(h, false);
                     }
                 }
-                case 'I' -> engine = new Engine(Integer.parseInt(line.substring(1).trim()));
+                case 'I' -> {
+                    engine = new Engine(Integer.parseInt(line.substring(1).trim()));
+                    history.clear();
+                }
                 case 'Q' -> {
                     System.out.println("End of program");
                     stopExecution = true;
                 }
                 default -> System.out.println("Invalid command");
             }
-            if (record) {
+            if (record && cmd != 'H' && cmd != 'Q' && cmd != 'I') {
                 history.add(line);
             }
         } catch (Exception e) {

--- a/src/test/java/coen6761/project/CommandTest.java
+++ b/src/test/java/coen6761/project/CommandTest.java
@@ -61,8 +61,8 @@ class CommandTest extends RobotMotionTestBase {
     void testHistoryRecording() {
         invokeCmd("I 5", true);
         invokeCmd("D", true);
-        assertEquals(2, getHistory().size());
-        assertEquals("I 5", getHistory().get(0));
+        assertEquals(1, getHistory().size());
+        assertEquals("D", getHistory().get(0));
     }
 
     @Test

--- a/src/test/java/coen6761/project/IntegrationTest.java
+++ b/src/test/java/coen6761/project/IntegrationTest.java
@@ -50,6 +50,6 @@ class IntegrationTest extends RobotMotionTestBase {
         assertEquals(2, getEngine().state.x);
         assertEquals(3, getEngine().state.y);
         assertTrue(out.contains(">Replaying:"));
-        assertTrue(getHistory().contains("H"));
+        assertFalse(getHistory().contains("H"));
     }
 }


### PR DESCRIPTION
Summary : 
- clear command history on initialization
- stop recording replay and quit commands in history
- update tests to match the corrected history behavior

Verification
- mvn -q -Dtest=QATask3Test test
- mvn -q test
